### PR TITLE
add docker compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,19 @@ docker build --pull --no-cache -t lisenet/openvpn:latest .
 
 ## How to Deploy
 
-Deployment to Kubernetes is currently the only supported (and tested) method. If you would like to [contribute](CONTRIBUTING.md) and provide instructions for other deployment methods (e.g. Podman, Docker engine, Compose, Swarm etc), please consider raising a pull request.
+The following deployment methods are supported and tested:
 
-See [docs/kubernetes-deployment.md](./docs/kubernetes-deployment.md).
+* Kubernetes: see [docs/kubernetes-deployment.md](./docs/kubernetes-deployment.md).
+* Docker Compose: see [docs/docker-compose.md](./docs/docker-compose.md).
+
+If you would like to [contribute](CONTRIBUTING.md) and provide instructions for other deployment methods (e.g. Podman, Docker engine, Swarm etc), please consider raising a pull request.
 
 ## Tested On
 
 * OpenVPN server deployment:
   * Kubernetes 1.28 on Rocky 9 (QEMU/KVM).
   * Kubernetes 1.26 on Rocky 8 (QEMU/KVM).
+  * Docker Engine 29.5.3 with Docker Compose plugin 5.1.4 on Ubuntu 24.04 (VMware).
 * Clients:
   * Android App OpenVPN Connect 3.3.4 (9290).
   * OpenVPN 2.5.9 on Rocky 9.
@@ -60,6 +64,7 @@ See [docs/kubernetes-deployment.md](./docs/kubernetes-deployment.md).
   * OpenVPN 2.4.7 on Debian 10.
   * OpenVPN 2.5.5 on Ubuntu 22.04 LTS.
   * OpenVPN 2.4.7 on Ubuntu 20.04 LTS.
+  * OpenVPN Connect 3.8.1 on macOS 15.7.4.
 
 ## Contributing
 
@@ -68,4 +73,3 @@ See [docs/kubernetes-deployment.md](./docs/kubernetes-deployment.md).
 ## License
 
 [LICENSE](./LICENSE)
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,83 @@
+x-openvpn-image: &openvpn-image lisenet/openvpn:${APP_VERSION:-latest}
+x-openvpn-volume: &openvpn-volume ./ovpn0:/etc/openvpn
+
+services:
+  openvpn:
+    image: *openvpn-image
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      net.ipv4.ip_forward: "1"
+      net.ipv4.conf.all.forwarding: "1"
+    ports:
+      - "${VPN_PORT:-31194}:1194/${VPN_PROTOCOL:-tcp}"
+    volumes:
+      - *openvpn-volume
+
+  generate-config:
+    image: *openvpn-image
+    profiles:
+      - setup
+    network_mode: none
+    environment:
+      # Required:
+      # VPN_HOSTNAME: domain or ip
+      VPN_PORT: 31194
+      VPN_PROTOCOL: tcp
+      DNS_SERVER: 1.1.1.1 8.8.8.8
+      NETWORK_CIDR: 10.8.0.0/24
+    volumes:
+      - *openvpn-volume
+    command:
+      - sh
+      - -c
+      - >-
+        ovpn_genconfig
+        -u "$${VPN_PROTOCOL}://$${VPN_HOSTNAME}:$${VPN_PORT}"
+        -C 'AES-256-GCM'
+        -a 'SHA384'
+        -b
+        -n "$${DNS_SERVER}"
+        -s "$${NETWORK_CIDR}"
+        -e 'topology subnet'
+
+  init-pki:
+    image: *openvpn-image
+    profiles:
+      - setup
+    network_mode: none
+    stdin_open: true
+    tty: true
+    volumes:
+      - *openvpn-volume
+    command:
+      - ovpn_initpki
+
+  copy-server-files:
+    image: *openvpn-image
+    profiles:
+      - setup
+    network_mode: none
+    volumes:
+      - *openvpn-volume
+    command:
+      - ovpn_copy_server_files
+
+  add-client:
+    image: *openvpn-image
+    profiles:
+      - client
+    network_mode: none
+    environment:
+      CLIENT_NAME: ${CLIENT_NAME:-user}
+      EASYRSA_ALGO: ${EASYRSA_ALGO:-ec}
+      EASYRSA_CURVE: ${EASYRSA_CURVE:-secp384r1}
+    volumes:
+      - *openvpn-volume
+    command:
+      - sh
+      - -c
+      - >-
+        easyrsa build-client-full "$${CLIENT_NAME}" &&
+        ovpn_getclient "$${CLIENT_NAME}" > "/etc/openvpn/$${CLIENT_NAME}.ovpn"

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -1,0 +1,62 @@
+# OpenVPN Server Deployment with Docker Compose
+
+OpenVPN server in a container running with Docker Compose.
+
+## Pre-requisites
+
+1. Docker Engine with Docker Compose plugin.
+2. A public DNS name or IP address for the OpenVPN server.
+
+### Docker Engine on Ubuntu
+
+Follow the official [Docker Engine installation guide for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#prerequisites).
+
+## Copy Docker Compose File
+
+Copy [docker-compose.yml](../docker-compose.yml) to the target server.
+
+## Configure Docker Compose
+
+Edit [docker-compose.yml](../docker-compose.yml) and set `VPN_HOSTNAME` in the `generate-config` service:
+
+```yaml
+VPN_HOSTNAME: vpn.example.com
+```
+
+Update the other variables in `docker-compose.yml` if you need to change the port, protocol, DNS server, or VPN network.
+
+## Generate OpenVPN Configuration Files and Certificates
+
+Generate the OpenVPN server config. The server config files are created in `./ovpn0`:
+
+```bash
+docker compose run --rm generate-config
+docker compose run --rm init-pki
+docker compose run --rm copy-server-files
+```
+
+Start the OpenVPN server:
+
+```bash
+docker compose up -d openvpn
+```
+
+The `init-pki` step is interactive because it asks for the CA password. For a fully non-interactive but less secure setup, run:
+
+```bash
+docker compose run --rm init-pki ovpn_initpki nopass
+```
+
+## Create a Client
+
+Generate a client configuration:
+
+```bash
+CLIENT_NAME=laptop0 docker compose run --rm add-client
+```
+
+The generated client file is written to:
+
+```text
+ovpn0/laptop0.ovpn
+```


### PR DESCRIPTION
  ## Summary

  Add Docker Compose support for running the OpenVPN server.

  ## Changes

  - Add `docker-compose.yml` with services for:
    - running the OpenVPN server
    - generating server config
    - initializing PKI
    - copying server files
    - generating client configs
  - Add Docker Compose deployment documentation.
  - Update README to list Docker Compose as a supported/tested deployment method.
  - Add tested Docker Engine, Docker Compose plugin.